### PR TITLE
Change URL format from get to path

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -45,7 +45,7 @@ return array(
         // ),
 
         'urlManager' => array(
-            'urlFormat' => 'get',
+            'urlFormat' => 'path',
             'rules' => array(
                 // You can add your own rules here
             ),


### PR DESCRIPTION
## Problem

<img width="1116" height="368" alt="image" src="https://github.com/user-attachments/assets/86c36f72-9240-4bc2-ae47-a3a4a2c934d4" />

LimeSurvey version 7 requires path URL format, for more info see
https://www.limesurvey.org/manual/LimeSurvey_7_Question_Editor#Switching_URL_format_from_%22get%22_to_%22path%22_to_enable_the_new_editor_in_LimeSurvey_7

## Solution

Switch URL format form `get` to `path`.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
