### PR TITLE
Update PHP version to 8.5

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -90,15 +90,15 @@ ram.runtime = "50M"
     [resources.apt]
     packages = [
         "python3-pip",
-        "php8.4-cli",
-        "php8.4-fpm",
-        "php8.4-mysql",
-        "php8.4-imap",
-        "php8.4-gd",
-        "php8.4-ldap",
-        "php8.4-zip",
-        "php8.4-mbstring",
-        "php8.4-xml",
+        "php8.5-cli",
+        "php8.5-fpm",
+        "php8.5-mysql",
+        "php8.5-imap",
+        "php8.5-gd",
+        "php8.5-ldap",
+        "php8.5-zip",
+        "php8.5-mbstring",
+        "php8.5-xml",
         "mariadb-server",
     ]
 


### PR DESCRIPTION
## Problem

Outdated PHP version. LimeSurey docker image uses PHP 8.5 from LimeSurvey version 7 on, see https://github.com/martialblog/docker-limesurvey#upgrading-to-70-from-6x .

## Solution

Increase PHP version.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
